### PR TITLE
Fixed linker error

### DIFF
--- a/implementations/num-c/Makefile
+++ b/implementations/num-c/Makefile
@@ -1,5 +1,5 @@
 all:
-	gcc -O3 num.c -o num
+	gcc -Wall -O3 num.c -o num -lm
 
 test:
 	./num-test


### PR DESCRIPTION
Without "-lm" it cannot find "sqrt" and fails with an error message like this:

```
gcc -O3 num.c -o num
/tmp/ccJrR6Pm.o: In function `num_standard_deviation'
num.c:(.text+0x59c): undefined reference to `sqrt'
/tmp/ccJrR6Pm.o: In function `num_coefficient_of_variance'
num.c:(.text+0x687): undefined reference to `sqrt'
collect2: error: ld returned 1 exit status
make: *** [Makefile:2: all] Error 1
```

Background: https://stackoverflow.com/questions/5248919/c-undefined-reference-to-sqrt-or-other-mathematical-functions
